### PR TITLE
Fixes to work with ubuntu 24.4 and 22.4

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -6,7 +6,7 @@ const child_process = require('child_process');
 const installPythonDependencies = () => {
   core.info('Installing Python dependencies...');
   child_process.execSync(
-    'sudo apt-get update && sudo apt-get install -y python3.9 python3-pip gcc build-essential libkrb5-dev python3-setuptools'
+    'sudo apt-get update && sudo apt-get install -y python3 pipx gcc build-essential libkrb5-dev python3-setuptools python3-lxml'
   );
   core.info('Setting Python3 as default');
   child_process.execSync(
@@ -16,22 +16,21 @@ const installPythonDependencies = () => {
 
 const installRequiredPipPackages = () => {
   core.info("Installing required PiP modules...");
-  child_process.execSync('pip3 install -U pip', {stdio: 'inherit'});
-  child_process.execSync('pip3 install wheel', {stdio: 'inherit'});
-  child_process.execSync('pip3 install odcs', {stdio: 'inherit'});
-  child_process.execSync('pip3 install docker', {stdio: 'inherit'});
-  child_process.execSync('pip3 install docker_squash', {stdio: 'inherit'});
-  child_process.execSync('pip3 install behave', {stdio: 'inherit'});
-  child_process.execSync('pip3 install lxml', {stdio: 'inherit'});
+  child_process.execSync('PIPX_BIN_DIR=/usr/local/bin pipx install pip', {stdio: 'inherit'});
+  child_process.execSync('PIPX_BIN_DIR=/usr/local/bin pipx install wheel', {stdio: 'inherit'});
+  child_process.execSync('PIPX_BIN_DIR=/usr/local/bin pipx install odcs', {stdio: 'inherit'});
+  child_process.execSync('PIPX_BIN_DIR=/usr/local/bin pipx install --include-deps docker', {stdio: 'inherit'});
+  child_process.execSync('PIPX_BIN_DIR=/usr/local/bin pipx install docker_squash', {stdio: 'inherit'});
+  child_process.execSync('PIPX_BIN_DIR=/usr/local/bin pipx install behave', {stdio: 'inherit'});
 };
 
 const install = inputs => {
   installPythonDependencies();
   installRequiredPipPackages();
   core.info('Installing CEKit...');
-  let cekitInstallCommand = 'pip install --user -U cekit';
+  let cekitInstallCommand = 'PIPX_BIN_DIR=/usr/local/bin pipx install cekit';
   if (inputs.version) {
-    cekitInstallCommand = `pip install --user cekit==${inputs.version}`;
+    cekitInstallCommand = `PIPX_BIN_DIR=/usr/local/bin pipx install cekit==${inputs.version}`;
   }
   child_process.execSync(cekitInstallCommand, {stdio: 'inherit'});
   core.addPath('/home/runner/.local/bin');


### PR DESCRIPTION
github ubuntu-latest is now 24.4 and python3.9 is not available via apt-get.
plus other changes needed in the installation procedure.

seems to work both with 24.4 and 22.4 (still served sometime by github)